### PR TITLE
Make onyx 0.10.x compatible with clojure 1.9

### DIFF
--- a/src/onyx/spec.cljc
+++ b/src/onyx/spec.cljc
@@ -1,7 +1,7 @@
 (ns onyx.spec
   (:require #?(:clj [clojure.spec.alpha :as s]
                :cljs [cljs.spec.alpha :as s :refer-macros [coll-of]])
-            #?(:clj [clojure.future :refer [any? boolean? uuid? pos-int?]])
+            #?(:clj [clojure.future :refer :all])
             [onyx.information-model :as i]
             [onyx.refinements :as r]
             [onyx.triggers :as t]))


### PR DESCRIPTION
`clojure-futre-spec` is compatible with clojure 1.9¹, but when refer a specific function to import, clojure 1.9 fail with `IllegalAccessError uuid? does not exist`

¹ https://github.com/tonsky/clojure-future-spec#clojure-future-spec